### PR TITLE
fix: simplify additional gfx driver logic

### DIFF
--- a/archinstall/lib/profile/profiles_handler.py
+++ b/archinstall/lib/profile/profiles_handler.py
@@ -189,26 +189,23 @@ class ProfileHandler:
 			install_session.enable_service(service)
 
 	def install_gfx_driver(self, install_session: 'Installer', driver: Optional[GfxDriver]):
+		additional_pkg = ['xorg-server', 'xorg-xinit']
 		try:
-			driver_pkgs = driver.packages() if driver else []
-			pkg_names = [p.value for p in driver_pkgs]
-			additional_pkg = ' '.join(['xorg-server', 'xorg-xinit'] + pkg_names)
-
 			if driver is not None:
-				# Find the intersection between the set of known nvidia drivers
-				# and the selected driver packages. Since valid intesections can
-				# only have one element or none, we iterate and try to take the
-				# first element.
-				if driver_pkg := next(iter({GfxPackage.Nvidia, GfxPackage.NvidiaOpen} & set(driver_pkgs)), None):
-					if any(kernel in install_session.base_packages for kernel in ("linux-lts", "linux-zen")):
-						for kernel in install_session.kernels:
-							# Fixes https://github.com/archlinux/archinstall/issues/585
-							install_session.add_additional_packages(f"{kernel}-headers")
+				driver_pkgs = driver.packages()
+				pkg_names = [p.value for p in driver_pkgs]
+				additional_pkg.extend(pkg_names)
+				for driver_pkg in {GfxPackage.Nvidia, GfxPackage.NvidiaOpen} & set(driver_pkgs):
+					for kernel in {"linux-lts", "linux-zen"} & set(install_session.kernels):
+						# Fixes https://github.com/archlinux/archinstall/issues/585
+						install_session.add_additional_packages(f"{kernel}-headers")
 
 						# I've had kernel regen fail if it wasn't installed before nvidia-dkms
-						install_session.add_additional_packages(['dkms', 'xorg-server', 'xorg-xinit', f'{driver_pkg}-dkms'])
-						return
-				elif 'amdgpu' in driver_pkgs:
+						install_session.add_additional_packages(['dkms', 'xorg-server', 'xorg-xinit', f'{driver_pkg.value}-dkms'])
+					# Break out of the loop and return after the first driver_pkg since only one or none can be used.
+					return
+				
+				if 'amdgpu' in pkg_names:
 					# The order of these two are important if amdgpu is installed #808
 					if 'amdgpu' in install_session.modules:
 						install_session.modules.remove('amdgpu')
@@ -217,12 +214,11 @@ class ProfileHandler:
 					if 'radeon' in install_session.modules:
 						install_session.modules.remove('radeon')
 					install_session.modules.append('radeon')
-
-			install_session.add_additional_packages(additional_pkg)
 		except Exception as err:
-			warn(f"Could not handle nvidia and linuz-zen specific situations during xorg installation: {err}")
+			warn(f"Could not handle nvidia and linux-zen specific situations during xorg installation: {err}")
 			# Prep didn't run, so there's no driver to install
-			install_session.add_additional_packages(['xorg-server', 'xorg-xinit'])
+
+		install_session.add_additional_packages(additional_pkg)
 
 	def install_profile_config(self, install_session: 'Installer', profile_config: ProfileConfiguration):
 		profile = profile_config.profile


### PR DESCRIPTION
- Use `driver_pkg.value` to get the driver package name instead of the enum type when using f-strings.
- Check for presence of `amdgpu` in `pkg_names` instead of `driver_pkgs`.
- Loop over Nvidia GFX packages that need dkms drivers, break and return after the first match. Nobody will be able use nvidia and nvidia-open at the same time.